### PR TITLE
Fix verify

### DIFF
--- a/cleanup_filesystem.go
+++ b/cleanup_filesystem.go
@@ -24,17 +24,18 @@ func CleanupFilesystem(agent string, namespace consul.Key, path string) error {
 		return err
 	}
 
-	log.Printf("Found these projects: %+v\n", projects)
+	log.Printf("Handling these projects: %+v\n", projects)
 
 	fs := filesystem.Deployment(path)
 
 	for _, project := range projects {
 		directories, err := fs.GetBranches(project)
-		if err != nil {
+		if err == filesystem.ProjectDirectoryNotFound {
+			log.Printf("Skipping project %#v, because project directory doesn't exists.", project)
+			continue
+		} else if err != nil {
 			return err
 		}
-
-		log.Printf("Found these directories in %#v: %+v\n", project, directories)
 
 		branches, err := client.GetBranches(project)
 		if err != nil {

--- a/filesystem/deployment.go
+++ b/filesystem/deployment.go
@@ -1,10 +1,15 @@
 package filesystem
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
 	"path"
+)
+
+var (
+	ProjectDirectoryNotFound = fmt.Errorf("Project directory does not exists.")
 )
 
 type Deployment string
@@ -41,6 +46,10 @@ func isDirectory(path string) bool {
 
 func (d *Deployment) GetBranches(project string) (Branches, error) {
 	directory := path.Join(string(*d), project)
+
+	if !isDirectory(directory) {
+		return nil, ProjectDirectoryNotFound
+	}
 
 	fileInfos, err := ioutil.ReadDir(directory)
 	if err != nil {

--- a/verify.go
+++ b/verify.go
@@ -37,7 +37,10 @@ func Verify(agent string, namespace consul.Key, path string) error {
 
 	for _, project := range projects {
 		directories, err := fs.GetBranches(project)
-		if err != nil {
+		if err == filesystem.ProjectDirectoryNotFound {
+			log.Printf("Skipping project %#v, because project directory doesn't exists.", project)
+			continue
+		} else if err != nil {
 			return err
 		}
 

--- a/verify.go
+++ b/verify.go
@@ -62,8 +62,11 @@ func Verify(agent string, namespace consul.Key, path string) error {
 			}
 		}
 
+		found := make(map[string]bool)
 		for _, branch := range distribution {
-			if !directories.Contains(branch) {
+			ok := found[branch]
+			if !directories.Contains(branch) && !ok {
+				found[branch] = true
 				log.Printf("%s/%s is distributed in Consul, but don't exists on disk!", project, branch)
 				failed = true
 			}


### PR DESCRIPTION
* log missing directory only once on `verify`
* skip project, if directory doesn't exists in `webroot` on `verify` and `filesystem` cleanup