### PR TITLE
use default commands for jenkins build

### DIFF
--- a/.jenkins.yml
+++ b/.jenkins.yml
@@ -1,5 +1,3 @@
 golang:
    mailerRecipients:
      - 'dl-scb-tech-platform@rebuy.de'
-   command:
-     - 'hack/build.sh'


### PR DESCRIPTION
@rebuy-de/prp-partial-deployment-cleanup remove the command which only compiles the binary and rely on the default go jenkins job commands: "go get; go test"